### PR TITLE
tweak the Dark Sky widget a little bit

### DIFF
--- a/dashboards/north.erb
+++ b/dashboards/north.erb
@@ -48,7 +48,7 @@ $(function() {
       <div data-id="transit-north" data-view="Iframe" data-url="/transit-north.html"></div>
     </li>
     <li id="darksky" data-row="15" data-col="1" data-sizex="4" data-sizey="2">
-      <div data-id="darksky" data-view="Rickshawgraph" data-title="Dark Sky" data-displayed-value="summary" style="background-color:#47bbb3;"></div>
+      <div data-id="darksky" data-view="Rickshawgraph" data-title="Dark Sky" data-displayed-value="summary" style="background-color:#47bbb3; vertical-align: top;"></div>
     </li>
   </ul>
 </div>

--- a/dashboards/south.erb
+++ b/dashboards/south.erb
@@ -50,7 +50,7 @@ $(function() {
       <div data-id="transit" data-view="Iframe" data-url="/transit.html"></div>
     </li>
     <li id="darksky" data-row="15" data-col="1" data-sizex="4" data-sizey="2">
-      <div data-id="darksky" data-view="Rickshawgraph" data-title="Dark Sky" data-displayed-value="summary" style="background-color:#47bbb3;"></div>
+      <div data-id="darksky" data-view="Rickshawgraph" data-title="Dark Sky" data-displayed-value="summary" style="background-color:#47bbb3; vertical-align: top;"></div>
     </li>
 <!--
     <li id="headlines" data-row="15" data-col="1" data-sizex="4" data-sizey="2">

--- a/jobs/darksky.rb
+++ b/jobs/darksky.rb
@@ -11,5 +11,5 @@ SCHEDULER.every '1m', :first_in => 0 do |job|
     upcoming << ({ x: i+1, y: json['minutely']['data'][i]['precipIntensity'] })
   end
 
-  send_event('darksky', { points: upcoming, summary: json['minutely']['summary'] })
+  send_event('darksky', { points: upcoming, summary: json['minutely']['summary'] + ' ' + json['hourly']['summary'] })
 end

--- a/widgets/rickshawgraph/rickshawgraph.coffee
+++ b/widgets/rickshawgraph/rickshawgraph.coffee
@@ -174,7 +174,9 @@ class Dashing.Rickshawgraph extends Dashing.Widget
     if Rickshaw.Fixtures.Time.Local
       xAxisOptions.timeFixture = new Rickshaw.Fixtures.Time.Local()
 
-    x_axis = new Rickshaw.Graph.Axis.X(graph: graph, tickFormat: Rickshaw.Fixtures.Number.formatMinutes)
+    x_axis = new Rickshaw.Graph.Axis.X(graph: graph, tickFormat: (x) ->
+      parseInt(x) + 'm'
+    )
     y_axis = new Rickshaw.Graph.Axis.Y(graph: graph, tickFormat: Rickshaw.Fixtures.Number.formatIntensity)
 
     if @get("legend")


### PR DESCRIPTION
- Aligns the text at the top of the widget, which looks better IMO.
- Adds the daily summary as well. ("Overcast for the hour. Light rain
  starting later this evening.")
- Replaces "15min" with "15m" which is less visual noise.

![](https://www.dropbox.com/s/ksvnb90roegl84d/Screenshot%202015-06-25%2017.19.34.PNG?dl=1)
